### PR TITLE
Update lib.es5.d.ts

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -1056,7 +1056,7 @@ interface JSON {
       * @param reviver A function that transforms the results. This function is called for each member of the object.
       * If a member contains nested objects, the nested objects are transformed before the parent object is.
       */
-    parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
+    parse<T = any>(text: string, reviver?: (this: any, key: string, value: any) => any): T;
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.


### PR DESCRIPTION
Update `JSON.parse` to accept optional type parameter and return this type "any by default".

Example:
```
let parsedObj = JSON.parse<TypeObj>("{ prop: 'val' }"); // parsedObj is TypeObj
```
is way better than
```
let parsedObj = JSON.parse("{ prop: 'val' }"); // parsedObj is any
```

Fixes #

updated 
```
parse(text: string, reviver?: (key: any, value: any) => any): any;
```
 to
```
parse<T = any>(text: string, reviver?: (key: any, value: any) => any): T;
```
